### PR TITLE
About link

### DIFF
--- a/disasterinfosite/templates/header.html
+++ b/disasterinfosite/templates/header.html
@@ -12,7 +12,7 @@
     </a>
     <div class="header__about header__about--small hide-for-medium-up--flex">
     {% block about-small %}
-      <a class="link--plain" href="/about"><h5 class="about__link link--grey">About</h5></a>
+      <a class="link--plain" href="{% url 'about' %}"><h5 class="about__link link--grey">About</h5></a>
       {% endblock about-small %}
       {% include "language_selector.html" %}
     </div>

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -34,9 +34,7 @@
         <h2 class="caps">{% trans "What are my risks?" %}</h2>
         <h3>{% trans "What to Expect" %}</h3>
         <p>
-          {% blocktrans %} {{ settings.site_title }} gives you an idea of which
-          natural disasters you might experience in the future based on a
-          location in {{ location.area_name }}. {% endblocktrans %}
+          {% blocktrans %} {{ settings.site_title }} gives you an idea of which natural disasters you might experience in the future based on a location in {{ location.area_name }}. {% endblocktrans %}
         </p>
 
         <h3>{% trans "How to Prepare" %}</h3>
@@ -46,9 +44,7 @@
 
         <h3>{% trans "In Recent History" %}</h3>
         <p>
-          {% blocktrans %} Find out which disasters have struck {{
-          location.area_name }} in the past, what impact they had, and where
-          they happened. {% endblocktrans %}
+          {% blocktrans %} Find out which disasters have struck {{ location.area_name }} in the past, what impact they had, and where they happened. {% endblocktrans %}
         </p>
       </div>
       {% endblock main-content %} {% include "users/user_interactions.html" %}

--- a/disasterinfosite/translation.py
+++ b/disasterinfosite/translation.py
@@ -1,7 +1,7 @@
 # Uncomment if you want to translate Django models.
 
 from modeltranslation.translator import register, translator, TranslationOptions
-from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, EmbedSnugget, SlideshowSnugget, SnuggetPopOut, SnuggetSection
+from .models import SiteSettings, Location, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, EmbedSnugget, SlideshowSnugget, SnuggetPopOut, SnuggetSection
 
 @register(SiteSettings)
 class SiteSettingsTranslationOptions(TranslationOptions):
@@ -10,14 +10,6 @@ class SiteSettingsTranslationOptions(TranslationOptions):
 @register(Location)
 class LocationTranslationOptions(TranslationOptions):
   fields = ('area_name', 'community_leaders')
-
-@register(SupplyKit)
-class SupplyKitTranslationOptions(TranslationOptions):
-  fields = ('text',)
-
-@register(ImportantLink)
-class ImportantLinkTranslationOptions(TranslationOptions):
-  fields = ('title',)
 
 @register(ShapefileGroup)
 class ShapefileGroupTranslationOptions(TranslationOptions):


### PR DESCRIPTION
Currently, the 'About' link from the 'Prepare' page doesn't work because the url is not being built with the site sitting in a subdirectory in mind.

I think this will fix it but I have to see it in action on the test server to be sure.