### PR TITLE
Use display name for snugget sections so that translations appear

### DIFF
--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -58,14 +58,14 @@
     {% for section, snuggets in hazard.items %}
       {% if section.collapsible %}
     <h4 class="section-title section-title--collapse" data-section="{{group.name}}-{{section.name|slugify}}">
-      <img class="caret" src="{% webpack_static 'build/caret.svg' %}" alt=""/>{{ section.name }}
+      <img class="caret" src="{% webpack_static 'build/caret.svg' %}" alt=""/>{{ section.display_name }}
     </h4>
     <div
       class="section-content section-content--collapse"
       id="{{group.name}}-{{section.name|slugify}}"
     >
       {% else %}
-      <h4 class="section-title--static">{{ section.name }}</h4>
+      <h4 class="section-title--static">{{ section.display_name }}</h4>
       <div class="section-content">
         {% endif %}
         <div class="snugget__content">


### PR DESCRIPTION
This is the fix for https://trello.com/c/JJ3nnfu0 - the names are the same as the English display names right now, because that's how they are organized in the snugget spreadsheet.