### PR TITLE
Popout styling fixes

### DIFF
--- a/disasterinfosite/static/style/_constants.scss
+++ b/disasterinfosite/static/style/_constants.scss
@@ -13,6 +13,7 @@ $dark-accent: #0037a7;
 $light-accent: #106edf;
 $bright-accent: #00a4b2;
 $popout-border: #2cb3b3;
+$popout-background: #2cb3b338;
 
 $low-intensity: #ffffb2;
 $moderate-intensity: #fed976;

--- a/disasterinfosite/static/style/_snugget-content.scss
+++ b/disasterinfosite/static/style/_snugget-content.scss
@@ -16,6 +16,7 @@
 /* Sections */
 .section-title--static {
   color: $soft-black;
+  margin-bottom: 0;
 }
 
 .section-title--collapse {
@@ -41,6 +42,7 @@
 .section-content {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   max-height: 9000px;
   overflow: hidden;
   transition: max-height 0.3s ease-out;
@@ -54,24 +56,37 @@
   max-height: 0;
 }
 
+.section-content--static {
+  position: relative;
+  overflow: visible;
+
+  .snugget__popout {
+    @include breakpoint(large) {
+      margin-top: -40px;
+    }
+  }
+}
+
 /* Snugget content */
 .snugget__content {
-  width: auto;
+  flex: 0 1 auto;
+  ul {
+    padding-left: 0;
+  }
 
-  @include breakpoint(large) {
-    width: 60%;
+  li {
+    margin-left: 20px;
   }
 }
 
 /* flex-basis is set to the width of the youtube embed */
 .snugget__popout {
-  flex-basis: 300px;
-  max-width: 100%;
+  flex: 1 0 auto;
+  margin: 10px 0 0 0;
 
   @include breakpoint(large) {
-    flex-basis: 340px;
-    margin: 0 0 0 auto;
-    width: 32%;
+    flex: 1 0 340px;
+    margin: 0 0 0 10px;
   }
 }
 
@@ -88,31 +103,35 @@
 }
 
 .popout-content {
-  border: 1px solid $popout-border;
-  border-left-width: 6px;
+  background-color: $popout-background;
+  border: 2px solid $popout-border;
+  border-top-width: 6px;
   padding: 10px;
   max-width: 100%;
 
-  @include breakpoint(medium) {
-    padding: 20px;
-  }
+  h4 {
+    color: $popout-border;
+    font-size: 18px;
+    margin: 10px 0 0 0;
 
-  @include breakpoint(large) {
-    border: none;
-    padding: 0 0 0 30px;
+    @include breakpoint(large) {
+      font-size: 21px;
+    }
+  }
+  p {
+    margin: 0;
   }
 }
 
 .popout__video {
-  max-width: 100%;
+  text-align: center;
+  width: 100%;
 }
 
 .popout__image {
-  max-width: 300px;
+  width: 100%;
+  text-align: center;
 
-  @include breakpoint(medium) {
-    width: 50%;
-  }
   @include breakpoint(large) {
     min-width: 175px;
     max-width: 100%;
@@ -193,24 +212,10 @@
 
 .past-photos {
   max-width: 100%;
-  height: 320px;
-  margin: 30px auto 0;
-
-  @include breakpoint(medium) {
-    width: 540px;
-    height: 400px;
-  }
 
   @include breakpoint(large) {
     width: 335px;
-    height: 320px;
   }
-}
-
-.past-photo__caption {
-  color: $medium-grey;
-  margin: 0 auto;
-  text-align: center;
 }
 
 .slideshow-image {

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -66,7 +66,7 @@
     >
       {% else %}
       <h4 class="section-title--static">{{ section.display_name }}</h4>
-      <div class="section-content">
+      <div class="section-content section-content--static">
         {% endif %}
         <div class="snugget__content">
           {% for snugget in snuggets|dictsort:"order" %}

--- a/disasterinfosite/templates/pop_out.html
+++ b/disasterinfosite/templates/pop_out.html
@@ -2,21 +2,7 @@
 
 {% block popout-content %}
 <div class="popout-content">
-  {% if snugget.pop_out.link %}
-    <a href="{{snugget.pop_out.link}}" target="_blank" rel="noopener">
-  {% endif %}
 
-  {% if snugget.pop_out.text %}
-    {{ snugget.pop_out.text | safe }}
-  {% endif %}
-
-  {% if snugget.pop_out.link %}
-    </a>
-  {% endif %}
-
-  {% if snugget.pop_out.image %}
-    <img class="popout__image" alt="{{ snugget.pop_out.alt_text }}" src="{{ snugget.pop_out.image.url }}"/>
-  {% endif %}
   {% if snugget.pop_out.video %}
 
     {% video snugget.pop_out.video as v %}
@@ -28,6 +14,22 @@
     </div>
     {% endvideo %}
 
+  {% endif %}
+
+  {% if snugget.pop_out.link %}
+    <a href="{{snugget.pop_out.link}}" target="_blank" rel="noopener">
+  {% endif %}
+
+  {% if snugget.pop_out.image %}
+    <img class="popout__image" alt="{{ snugget.pop_out.alt_text }}" src="{{ snugget.pop_out.image.url }}"/>
+  {% endif %}
+
+  {% if snugget.pop_out.text %}
+    {{ snugget.pop_out.text | safe }}
+  {% endif %}
+
+  {% if snugget.pop_out.link %}
+    </a>
   {% endif %}
 
   {% if snugget.photos %}


### PR DESCRIPTION
For https://trello.com/c/sZ4kzFL1 

- makes the popouts smaller and take up less space around themselves
- Align tops of popouts with tops of section titles (not top of section content) for non-collapsible sections
- Make popout text have teal outline on all screen sizes and a teal background color
- Popout text goes under the photo now and videos now
