### PR TITLE
Swipey tabs

### DIFF
--- a/disasterinfosite/package-lock.json
+++ b/disasterinfosite/package-lock.json
@@ -5393,9 +5393,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
-      "integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz",
+      "integrity": "sha512-OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",

--- a/disasterinfosite/package.json
+++ b/disasterinfosite/package.json
@@ -30,7 +30,7 @@
     "url-polyfill": "^1.1.7",
     "webpack": "^4.39.2",
     "webpack-bundle-tracker": "^0.4.2-beta",
-    "webpack-cli": "^3.3.6"
+    "webpack-cli": "^3.3.7"
   },
   "dependencies": {
     "formdata-polyfill": "^3.0.19",

--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -211,14 +211,48 @@ $(document).ready(function() {
   var heroContainer = $(".hero-container");
   var contentContainer = $(".content-container");
 
-  // if we are on the found content page, stick the hero container and lazy load our videos.
+  // if we are on the found content page, stick the hero container, set up our tabs and lazy load our videos.
   if (infoContainer.length) {
     var stopHeight = setStopHeight(heroContainer);
 
+    var hazardLinks = $('.hazard-link');
+
+    // get the hash, if there is one, and select the correct tab
+    var anchor = window.location.hash;
+    $('a[href="' + anchor + '"]').addClass('selected');
+
+    // Select the correct tab when we click on one
+    hazardLinks.click(function(event) {
+      hazardLinks.removeClass('selected');
+      $(event.delegateTarget).addClass('selected');
+    });
+
+    // Highlight the correct hazard tabs as we scroll
+    var anchors = $('.anchor');
+    var previousHazard;
+
     var stickMenu = function() {
-      if ($(document).scrollTop() >= stopHeight) {
+      var scrollTop = $(document).scrollTop();
+      if (scrollTop >= stopHeight) {
         heroContainer.addClass("sticky");
         contentContainer.css({ "padding-top": stopHeight + 100 + "px" });
+
+        // Get id of current hazard
+         var currentHazard = anchors.filter(function(){
+          var container = $(this).parent();
+          var top = container.offset().top - 200;
+          return (top <= scrollTop && container.outerHeight() + top >= scrollTop)
+         }).attr('id');
+
+         if(currentHazard !== previousHazard) {
+            previousHazard = currentHazard;
+            hazardLinks.removeClass('selected');
+            var currentTab = $('a[href="#' + currentHazard + '"]');
+            currentTab.addClass('selected');
+            if(currentTab[0]) {
+              currentTab[0].scrollIntoView();
+            }
+         }
       } else {
         heroContainer.removeClass("sticky");
         contentContainer.css({ "padding-top": "" });

--- a/disasterinfosite/static/style/_map.scss
+++ b/disasterinfosite/static/style/_map.scss
@@ -1,7 +1,6 @@
 /* Information and Instructions */
 .hero-container {
   min-height: 300px;
-  padding-bottom: 20px;
   transition: 0.5s background-color ease, 0.5s min-height ease;
 
   .survey-link {
@@ -81,6 +80,11 @@
   .survey-link {
     display: block;
   }
+
+  .hazard-link.selected {
+    border-bottom: 2px solid $dark-accent;
+    color: $dark-accent;
+  }
 }
 
 .information-container {
@@ -119,20 +123,17 @@
 
 .hazard-container {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-around;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: space-between;
   margin-top: 10px;
-
-  @include breakpoint(medium-and-up) {
-    justify-content: space-between;
-  }
+  overflow: scroll;
+  padding-bottom: 10px;
 }
 
 .hazard-link, .prepare-link {
   border-bottom: 2px solid $soft-white;
   color: $bright-accent;
-  margin: 5px;
+  margin: 5px 10px;
   text-decoration: none;
 
   &:focus, &:hover, &:active {


### PR DESCRIPTION
Instead of showing all the tabs at once in the headers, make it so that you can scroll sideways to use them.

Also, if you navigate to, link directly to, or *scroll* to a section, the tab name is highlighted when the header is sticky:

![image](https://user-images.githubusercontent.com/547883/63305006-11bf1b80-c29a-11e9-8479-4859308aabcd.png)

![image](https://user-images.githubusercontent.com/547883/63305058-34513480-c29a-11e9-919c-86ae20d3231c.png)
