### PR TITLE
Let the Django backend tell me where our api endpoints are

### DIFF
--- a/disasterinfosite/static/js/prepare.js
+++ b/disasterinfosite/static/js/prepare.js
@@ -79,7 +79,7 @@ $(document).ready(function() {
             xhr.setRequestHeader("X-CSRFToken", csrftoken);
           },
           method: "POST",
-          url: "/accounts/update_prepare_action/",
+          url: prepareActionApiUrl,
           data: {
             action: $checkbox.val(),
             taken: $checkbox.is(":checked")

--- a/disasterinfosite/static/js/users.js
+++ b/disasterinfosite/static/js/users.js
@@ -105,7 +105,7 @@ $(document).ready(function() {
 
   $(".button--logout").click(function(event) {
     event.preventDefault();
-    sendAjaxAuthRequest("/accounts/logout/")
+    sendAjaxAuthRequest(logoutApiUrl)
       .done(function() {
         location.reload(true);
       })
@@ -120,7 +120,7 @@ $(document).ready(function() {
   $signupForm.submit(function(event) {
     event.preventDefault();
 
-    sendAjaxAuthRequest("/accounts/create_user/", new FormData($signupForm[0]))
+    sendAjaxAuthRequest(createUserApiUrl, new FormData($signupForm[0]))
     .done(function() {
       $("#user-signup-result-container").removeClass('hide');;
     })
@@ -136,7 +136,7 @@ $(document).ready(function() {
   $loginForm.submit(function(event) {
     event.preventDefault();
 
-    sendAjaxAuthRequest("/accounts/login/", new FormData($loginForm[0]))
+    sendAjaxAuthRequest(loginApiUrl, new FormData($loginForm[0]))
       .done(function() {
         location.hash = "user-interaction-container";
         location.reload(true);
@@ -151,7 +151,7 @@ $(document).ready(function() {
   $updateForm.submit(function(event) {
     event.preventDefault();
 
-    sendAjaxAuthRequest("/accounts/update_profile/", new FormData($updateForm[0]))
+    sendAjaxAuthRequest(updateProfileApiUrl, new FormData($updateForm[0]))
       .done(function() {
         $("#user-profile-result-container").removeClass('hide');;
       })

--- a/disasterinfosite/templates/head-meta.html
+++ b/disasterinfosite/templates/head-meta.html
@@ -25,6 +25,14 @@
 
   <link rel="shortcut icon" href="{% webpack_static 'build/favicon.ico' %}"/>
   <script type="text/javascript">
+    // so our js can know what our data bounds are
     var mapBounds = {{ data_bounds | js }};
+
+    // so our js can know where our api urls are when we run in a subdirectory
+    var loginApiUrl = "{% url "login" %}"
+    var logoutApiUrl = "{% url "logout" %}"
+    var createUserApiUrl = "{% url "create_user" %}"
+    var updateProfileApiUrl = "{% url "update_profile" %}"
+    var prepareActionApiUrl = "{% url "prepare_action_update" %}"
   </script>
 </head>

--- a/disasterinfosite/urls.py
+++ b/disasterinfosite/urls.py
@@ -11,10 +11,10 @@ urlpatterns = [
   url(r'^i18n/', include('django.conf.urls.i18n')),
   # API urls
   url(r'^survey/$', views.add_survey_code, name="survey"),
-  url(r'^accounts/login/$', views.login_view),
-  url(r'^accounts/logout/$', views.logout_view),
-  url(r'^accounts/create_user/$', views.create_user),
-  url(r'^accounts/update_profile/$', views.update_profile),
+  url(r'^accounts/login/$', views.login_view, name="login"),
+  url(r'^accounts/logout/$', views.logout_view, name="logout"),
+  url(r'^accounts/create_user/$', views.create_user, name="create_user"),
+  url(r'^accounts/update_profile/$', views.update_profile, name="update_profile"),
   url(r'^accounts/update_prepare_action/$', views.prepare_action_update, name='prepare_action_update')
 ]
 


### PR DESCRIPTION
For https://trello.com/c/9CSLJ3f1

Our API endpoints were where I expected them to be when I was working on my machine, but when I put it up on the test server, they were... NOT... because we are deployed in a subdirectory.

The Django backend knows about our subdirectory though, so I can let it tell the javascript where its API endpoints are instead of hard-coding them in the js.

This also means that we can change those urls whenever we want for any reason, and not have to change the javascript at all, but that's not the most interesting thing for our particular use case.