### PR TITLE
Get rid of the flash of unstyled content

### DIFF
--- a/disasterinfosite/static/style/_utilities.scss
+++ b/disasterinfosite/static/style/_utilities.scss
@@ -108,3 +108,9 @@
   position: absolute;
   top: -110px;
 }
+
+/* This needs to stay the last piece of css that gets loaded, to prevent a FOUC */
+html {
+  visibility: visible;
+  opacity: 1;
+}

--- a/disasterinfosite/templates/head-meta.html
+++ b/disasterinfosite/templates/head-meta.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load js %}
 
 {% load webpack_static from webpack_loader %}
 {% load render_bundle from webpack_loader %}

--- a/disasterinfosite/templates/head-meta.html
+++ b/disasterinfosite/templates/head-meta.html
@@ -15,24 +15,18 @@
 
   <title>{{ settings.site_title }}</title>
 
+  <style>html{visibility: hidden; opacity:0;}</style>
+
  <!-- Load fonts -->
  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i|Source+Serif+Pro:600,700" rel="stylesheet">
+  {% render_bundle file 'css' %}
 
  <!-- Load MapQuest Places search styles (for autocomplete) from CDN -->
  <link type="text/css" rel="stylesheet" href="https://api.mqcdn.com/sdk/place-search-js/v1.0.0/place-search.css"/>
 
-  {% render_bundle file 'css' %}
-
   <link rel="shortcut icon" href="{% webpack_static 'build/favicon.ico' %}"/>
   <script type="text/javascript">
-    // so our js can know what our data bounds are
-    var mapBounds = {{ data_bounds | js }};
-
-    // so our js can know where our api urls are when we run in a subdirectory
-    var loginApiUrl = "{% url "login" %}"
-    var logoutApiUrl = "{% url "logout" %}"
-    var createUserApiUrl = "{% url "create_user" %}"
-    var updateProfileApiUrl = "{% url "update_profile" %}"
-    var prepareActionApiUrl = "{% url "prepare_action_update" %}"
+    // So we know whether the user has javascript or not
+    (function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)
   </script>
 </head>

--- a/disasterinfosite/templates/page-end-meta.html
+++ b/disasterinfosite/templates/page-end-meta.html
@@ -1,4 +1,5 @@
 {% load render_bundle from webpack_loader %}
+{% load js %}
 
 {% render_bundle 'vendor' 'js' %}
 

--- a/disasterinfosite/templates/page-end-meta.html
+++ b/disasterinfosite/templates/page-end-meta.html
@@ -2,6 +2,18 @@
 
 {% render_bundle 'vendor' 'js' %}
 
+<script>
+    // so our js can know what our data bounds are
+  var mapBounds = {{ data_bounds | js }};
+
+  // so our js can know where our api urls are when we run in a subdirectory
+  var loginApiUrl = "{% url "login" %}"
+  var logoutApiUrl = "{% url "logout" %}"
+  var createUserApiUrl = "{% url "create_user" %}"
+  var updateProfileApiUrl = "{% url "update_profile" %}"
+  var prepareActionApiUrl = "{% url "prepare_action_update" %}"
+</script>
+
 {% render_bundle file 'js' %}
 
 <!-- script for Google Analytics -->


### PR DESCRIPTION
For https://trello.com/c/QycAhFwD

It's a very very basic solution for this but it will make things 90% prettier to look at. Basically, I'm hiding the entire page until I know that all of our CSS has loaded, so the user doesn't see that weird ugly looking unstyled content before the page settles down and looks right.

Other things I did in here because they are just a good idea:
- loading our CSS before the remote stuff from MapQuest (the code that uses that isn't instantiated until you click on the text box, so it's safe to make that slower)
- making our 'no-js' vs. 'js' class on `<html>` mean something
- moving all scripts that can be in the footer to the page footer