### PR TITLE
Swipey tabs and data sources

### DIFF
--- a/disasterinfosite/locale/es/LC_MESSAGES/django.po
+++ b/disasterinfosite/locale/es/LC_MESSAGES/django.po
@@ -1,10 +1,9 @@
 # Localized strings for PDX Ready, Spanish.
 # Copyright (C) 2019
-
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-28 22:15+0000\n"
+"POT-Creation-Date: 2019-09-03 16:52+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -144,30 +143,32 @@ msgstr ""
 "información actualizada y la presenta de tal manera que sea accesible para "
 "cualquier residente de %(area_name)s."
 
-#: templates/about.html:127 templates/index.html:34
+#: templates/about.html:128 templates/index.html:35
 #, python-format
 msgid ""
 "This site uses the most up-to-date hazard risk data available for "
 "%(area_name)s. The user of this site is responsible for verifying any "
-"particular information with the original data sources. Although these data "
-"represent the best current assessment of hazards, they are not predictive of "
-"future events. The descriptions of risk and how to prepare for those risks "
-"are based on best information from the American Red Cross and the Federal "
-"Emergency Management Agency."
+"particular information with the original <a href=\"%(data_source_link)s\" "
+"target=\"_blank\">data sources</a>. Although these data represent the best "
+"current assessment of hazards, they are not predictive of future events. The "
+"descriptions of risk and how to prepare for those risks are based on best "
+"information from the American Red Cross and the Federal Emergency Management "
+"Agency."
 msgstr ""
 "Este sitio utiliza los datos de riesgo más actualizados para %(area_name)s. "
 "El usuario de este sitio es responsable de verificar cualquier información "
-"particular con las fuentes de datos originales. Aunque estos datos "
+"particular con las <a href=\"%(data_source_link)s\" "
+"target=\"_blank\">fuentes de datos</a> originales. Aunque estos datos "
 "representan la mejor evaluación actual de los peligros, no predicen eventos "
 "futuros. Las descripciones de riesgo y cómo prepararse para esos riesgos se "
 "basan en la mejor información de la Cruz Roja y la Federal Emergency "
 "Management Agency (Agencia Federal para el Manejo de Emergencias)."
 
-#: templates/about.html:131
+#: templates/about.html:132
 msgid "build/flowchart.jpg"
 msgstr "build/flowchart-es.jpg"
 
-#: templates/about.html:134
+#: templates/about.html:135
 msgid ""
 "How we build Hazard Ready Sites: 1. Gather data. Locate the most relevant "
 "and up-to-date data on natural hazards for your region from trusted sources "
@@ -192,7 +193,7 @@ msgstr ""
 "la información se ajuste a las necesidades de cada comunidad. 6. ¡Revisamos, "
 "revisamos, revisamos y lanzamos el sitio!"
 
-#: templates/about.html:142
+#: templates/about.html:143
 #, python-format
 msgid ""
 "Data used for %(title)s is available for download <a href=\"%(download)s\" "
@@ -201,11 +202,11 @@ msgstr ""
 "La información utilizada para %(title)s se puede descargar <a href="
 "\"%(download)s\" target=\"_blank\" rel=\"noopener\">aquí</a>"
 
-#: templates/about.html:149
+#: templates/about.html:150
 msgid "Quick Data Overview"
 msgstr "Descripción breve de los datos"
 
-#: templates/about.html:151
+#: templates/about.html:152
 #, python-format
 msgid "Take a look at some overviews of the data we used for %(area_name)s:"
 msgstr ""
@@ -219,7 +220,8 @@ msgstr "Qué puede esperar para"
 msgid "try&nbsp;a&nbsp;new&nbsp;address"
 msgstr "intente&nbsp;una&nbsp;nueva&nbsp;dirección"
 
-#: templates/found_content.html:23 templates/header.html:22
+#: templates/found_content.html:23 templates/header.html:21
+#: templates/header.html:51
 msgid "Feedback Survey"
 msgstr "Encuesta para ofrecer sus reflecciones"
 
@@ -265,11 +267,11 @@ msgid ""
 "Have questions? View the <a href=\"%(about_url)s\" target=\"_blank\">About</"
 "a> page for more information.\""
 msgstr ""
-"¿Tiene preguntas? Mire al <a href=\"%(about_url)s\" target="
-"\"_blank\">Sobre</a> pagina para mas información.\n"
+"¿Tiene preguntas? Mire al <a href=\"%(about_url)s\" target=\"_blank\">Sobre</"
+"a> pagina para mas información.\n"
 "            "
 
-#: templates/head-meta.html:13
+#: templates/head-meta.html:12
 msgid ""
 "Enter your location for a personalized report on your risks and how to "
 "prepare."
@@ -277,19 +279,19 @@ msgstr ""
 "Ingrese su localidad para obtener un informe personalizado de sus riesgos y "
 "cómo prepararse."
 
-#: templates/header.html:14 templates/header.html:46
+#: templates/header.html:14 templates/header.html:44
 msgid "About"
 msgstr "Sobre"
 
-#: templates/header.html:27
+#: templates/header.html:25
 msgid "Find Me"
 msgstr "Busqueme"
 
-#: templates/header.html:30
+#: templates/header.html:28
 msgid "Enter an address."
 msgstr "Introduzca una dirección."
 
-#: templates/header.html:40
+#: templates/header.html:38
 msgid "We had a problem finding that location."
 msgstr "Tuvimos un problema en encontrar esa localidad."
 
@@ -309,7 +311,7 @@ msgstr ""
 "superior de la página, seleccione una localidad en el mapa o haga clic en "
 "\"BUSQUEME.\""
 
-#: templates/index.html:52
+#: templates/index.html:53
 msgid "Getting results for your location..."
 msgstr "Obtener resultados para su localidad..."
 

--- a/disasterinfosite/locale/es/LC_MESSAGES/django.po
+++ b/disasterinfosite/locale/es/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-03 16:52+0000\n"
+"POT-Creation-Date: 2019-09-03 22:26+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -157,12 +157,12 @@ msgid ""
 msgstr ""
 "Este sitio utiliza los datos de riesgo más actualizados para %(area_name)s. "
 "El usuario de este sitio es responsable de verificar cualquier información "
-"particular con las <a href=\"%(data_source_link)s\" "
-"target=\"_blank\">fuentes de datos</a> originales. Aunque estos datos "
-"representan la mejor evaluación actual de los peligros, no predicen eventos "
-"futuros. Las descripciones de riesgo y cómo prepararse para esos riesgos se "
-"basan en la mejor información de la Cruz Roja y la Federal Emergency "
-"Management Agency (Agencia Federal para el Manejo de Emergencias)."
+"particular con las <a href=\"%(data_source_link)s\" target=\"_blank"
+"\">fuentes de datos</a> originales. Aunque estos datos representan la mejor "
+"evaluación actual de los peligros, no predicen eventos futuros. Las "
+"descripciones de riesgo y cómo prepararse para esos riesgos se basan en la "
+"mejor información de la Cruz Roja y la Federal Emergency Management Agency "
+"(Agencia Federal para el Manejo de Emergencias)."
 
 #: templates/about.html:132
 msgid "build/flowchart.jpg"
@@ -211,6 +211,84 @@ msgstr "Descripción breve de los datos"
 msgid "Take a look at some overviews of the data we used for %(area_name)s:"
 msgstr ""
 "Observe algunas descripciones de los datos que utilizamos para %(area_name)s:"
+
+#: templates/data.html:16
+msgid "Data sources for PDX Ready"
+msgstr "Fuentes de datos para PDX Lista"
+
+#: templates/data.html:18
+msgid "Clackamas, Columbia, Multnomah, and Washington Counties, Oregon"
+msgstr ""
+
+#: templates/data.html:20 templates/data.html:49
+msgid "Earthquake"
+msgstr "Terremoto"
+
+#: templates/data.html:21 templates/data.html:22 templates/data.html:26
+#: templates/data.html:27 templates/data.html:28 templates/data.html:29
+#: templates/data.html:30 templates/data.html:34 templates/data.html:38
+#: templates/data.html:39 templates/data.html:43 templates/data.html:50
+#: templates/data.html:51 templates/data.html:55 templates/data.html:59
+#: templates/data.html:63 templates/data.html:67
+msgid "accessed"
+msgstr ""
+
+#: templates/data.html:21 templates/data.html:22 templates/data.html:26
+#: templates/data.html:27 templates/data.html:28 templates/data.html:29
+#: templates/data.html:30 templates/data.html:34 templates/data.html:38
+#: templates/data.html:43 templates/data.html:50 templates/data.html:51
+#: templates/data.html:55 templates/data.html:59 templates/data.html:63
+#: templates/data.html:67
+msgid "June"
+msgstr "junio"
+
+#: templates/data.html:25 templates/data.html:54
+msgid "Volcano"
+msgstr "Volcán"
+
+#: templates/data.html:33 templates/data.html:58
+msgid "Landslide"
+msgstr "Derrumbes"
+
+#: templates/data.html:37 templates/data.html:62
+msgid "Flood"
+msgstr "Inundacion"
+
+#: templates/data.html:39
+msgid "August"
+msgstr "agosto"
+
+#: templates/data.html:42 templates/data.html:66
+msgid "Wildfire"
+msgstr "Incendio Forestal"
+
+#: templates/data.html:47
+msgid "Clark County, Washington"
+msgstr "Clark County, Washington"
+
+#: templates/data.html:71
+msgid "Questions or concerns about the data? Contact:"
+msgstr ""
+
+#: templates/data.html:73 templates/data.html:74
+msgid "flood"
+msgstr "inundacion"
+
+#: templates/data.html:74 templates/data.html:75 templates/data.html:77
+msgid "earthquake"
+msgstr "terremoto"
+
+#: templates/data.html:74 templates/data.html:77
+msgid "landslide"
+msgstr "derrumbes"
+
+#: templates/data.html:75
+msgid "volcano"
+msgstr "volcán"
+
+#: templates/data.html:76
+msgid "wildfire"
+msgstr "incendio forestal"
 
 #: templates/found_content.html:11
 msgid "What to expect for"

--- a/disasterinfosite/static/js/data.js
+++ b/disasterinfosite/static/js/data.js
@@ -1,0 +1,2 @@
+require("normalize.css/normalize.css");
+require("../style/data.scss");

--- a/disasterinfosite/static/style/_map.scss
+++ b/disasterinfosite/static/style/_map.scss
@@ -128,7 +128,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  overflow: scroll;
+  overflow-x: scroll;
   padding-bottom: 5px;
 }
 

--- a/disasterinfosite/static/style/data-page.scss
+++ b/disasterinfosite/static/style/data-page.scss
@@ -1,0 +1,23 @@
+.hazard-header {
+  color: $soft-black;
+}
+
+.quake {
+  background-color: $bright-accent;
+}
+
+.volcano {
+  background-color: $low-intensity;
+}
+
+.landslide {
+  background-color: $moderate-intensity;
+}
+
+.flood {
+ background-color: $high-intensity;
+}
+
+.wildfire {
+  background-color: $extreme-intensity;
+}

--- a/disasterinfosite/static/style/data.scss
+++ b/disasterinfosite/static/style/data.scss
@@ -1,0 +1,7 @@
+@import "constants";
+@import "mixins";
+@import "base";
+@import "header";
+@import "geek-box";
+@import "data-page";
+@import "utilities";

--- a/disasterinfosite/templates/about.html
+++ b/disasterinfosite/templates/about.html
@@ -123,7 +123,7 @@
           <p>
               {% blocktrans with title=settings.site_title area_name=settings.area_name %}{{ title }} is designed to help educate and prepare people for disasters that occur in their area. Disasters don’t strike locations equally so we found it important to give location specific information in order to properly prepare. {{ title }} organizes current information and packages it in a way that makes it accessible for any {{ area_name }} resident.{% endblocktrans %}
           </p>
-           {% webpack_static 'build/data-sources.pdf' as data_source_link %}
+           {% url 'data' as data_source_link %}
           <p>
               {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original <a href="{{ data_source_link }}" target="_blank">data sources</a>. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
           </p>

--- a/disasterinfosite/templates/about.html
+++ b/disasterinfosite/templates/about.html
@@ -123,8 +123,9 @@
           <p>
               {% blocktrans with title=settings.site_title area_name=settings.area_name %}{{ title }} is designed to help educate and prepare people for disasters that occur in their area. Disasters don’t strike locations equally so we found it important to give location specific information in order to properly prepare. {{ title }} organizes current information and packages it in a way that makes it accessible for any {{ area_name }} resident.{% endblocktrans %}
           </p>
+           {% webpack_static 'build/data-sources.pdf' as data_source_link %}
           <p>
-              {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original data sources. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
+              {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original <a href="{{ data_source_link }}" target="_blank">data sources</a>. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
           </p>
         </div>
         <div class="about-content__flowchart">

--- a/disasterinfosite/templates/data.html
+++ b/disasterinfosite/templates/data.html
@@ -17,12 +17,12 @@
     <div class="data-source-container">
       <h3 class="county-header">{% trans 'Clackamas, Columbia, Multnomah, and Washington Counties, Oregon' %}</h3>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Earthquake' %}</h4>
+        <h4 class="hazard-header quake">{% trans 'Earthquake' %}</h4>
         <p>Bauer, J.M., Burns, W.J., Madin, I.P., 2018, Open-File Report O-18-02, Earthquake regional impact analysis for Clackamas, Multnomah, and Washington counties, Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-18-02.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-18-02.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019 .</p>
         <p>Madin, I.P. and Burns, W.J., 2013, Open-File Report O-13-06, Ground motion, ground deformation, tsunami inundation, coseismic subsidence, and damage potential maps for the 2012 Oregon Resilience Plan for Cascadia Subduction Zone Earthquakes, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-13-06.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-13-06.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Volcano' %}</h4>
+        <h4 class="hazard-header volcano">{% trans 'Volcano' %}</h4>
         <p>Schilling, S.P., Doelger, S., Scott, W.E., Pierson, T.C., Costa, J.E., Gardner, C.A., Vallance, J.W., Major, J.J., 2008, Digital Data for Volcano Hazards of the Mount Hood Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1222/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1222/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
         <p>Schilling, S.P., Doelger, S., D.R. Sherrod, L.G. Mastin, and W.E. Scott, 2008, Digital Data for Volcano Hazards at Newberry Volcano, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1225/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1225/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
         <p>Schilling, S.P., Doelger, S., C.R. Bacon, L.G. Mastin, K.E. Scott, and M. Nathenson, 2008, Digital Data for Volcano Hazards in the Crater Lake Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1223/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1223/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
@@ -30,40 +30,40 @@
         <p>Schilling, S.P., Doelger, S., Scott, W.E., Iverson, R.M., 2008, Hazard Zones -- Digital Data for Volcano Hazards of the Three Sisters Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1221/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1221/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Landslide' %}</h4>
+        <h4 class="hazard-header landslide">{% trans 'Landslide' %}</h4>
         <p>Burns, W.J., Mickelson, K.A., Madin, I.P., 2016, Open-File Report O-16-02, Landslide Susceptibility Overview Map of Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-16-02.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-16-02.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Flood' %}</h4>
+        <h4 class="hazard-header flood">{% trans 'Flood' %}</h4>
         <p>DOGAMI, 2015, Oregon Statewide Flood Hazard Database - Other Flood Studies, Oregon Department of Geology and Mining Industries: <a href="https://spatialdata.oregonexplorer.info/geoportal/details;id=584a7d2df65d4751979b23b746d92024" target="_blank" rel="noopener">https://spatialdata.oregonexplorer.info/geoportal/details;id=584a7d2df65d4751979b23b746d92024</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
         <p>Appleby, C.A. and Bauer, J.M., 2018, Special Paper 50, Flood risk assessment for the Columbia Corridor drainage districts in Multnomah County, Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/sp/p-SP-50.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/sp/p-SP-50.htm</a>, {% trans 'accessed' %} {% trans 'August' %} 8, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Wildfire' %}</h4>
+        <h4 class="hazard-header wildfire">{% trans 'Wildfire' %}</h4>
         <p>Gilbertson-Day, J.W., Scott, J.H., Vogler, K.C., Brough, A., 2018, Pacific Northwest Quantitative Wildfire Risk Assessment, U.S. Forest Service and Oregon Department of Forestry: <a href="https://tools.oregonexplorer.info/OE_HtmlViewer/index.html?viewer=wildfireplanning" target="_blank" rel="noopener">https://tools.oregonexplorer.info/OE_HtmlViewer/index.html?viewer=wildfireplanning</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
     </div>
     <div class="data-source-container">
       <h3 class="county-header">{% trans 'Clark County, Washington' %}</h3>
             <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Earthquake' %}</h4>
+        <h4 class="hazard-header quake">{% trans 'Earthquake' %}</h4>
         <p>USGS, 2017, M 9.3 Scenario Earthquake - Cascadia Megathrust - whole CSZ Characteristic largest M branch (MMI Shakemap Data), U.S. Geological Survey: <a href="https://earthquake.usgs.gov/scenarios/eventpage/bssc2014cascadia_sub0_m9p34_se/shakemap/intensity" target="_blank" rel="noopener">https://earthquake.usgs.gov/scenarios/eventpage/bssc2014cascadia_sub0_m9p34_se/shakemap/intensity</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
         <p>Palmer,S.P., Magsino, S.L., Bilderback, E.L., Poelstra, J.L., Folger, D.S., Niggemann, R.A., 2004, Open File Report 2004-20 Liquefaction Susceptibility and Site Class Maps of Washington State, Clark County, Washington Department of Natural Resources: <a href="ftp://ww4.dnr.wa.gov/geology/pubs/ofr04-20/ofr2004-20_sheet11_clark_liq.pdf" target="_blank" rel="noopener">ftp://ww4.dnr.wa.gov/geology/pubs/ofr04-20/ofr2004- 20_sheet11_clark_liq.pdf</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Volcano' %}</h4>
+        <h4 class="hazard-header volcano">{% trans 'Volcano' %}</h4>
         <p>Wolfe, E.W. and Pierson, T.C. , 1995, Open-File Report 95–497: Volcanic-hazard zonation for Mount St. Helens, Washington, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/1996/0178/" target="_blank" rel="noopener">https://pubs.usgs.gov/of/1996/0178/</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Landslide' %}</h4>
+        <h4 class="hazard-header landslide">{% trans 'Landslide' %}</h4>
         <p>Washington DNR and Merrick & Company, 1975, 1987, 2002, Landslide Hazard Areas: combined from 'Slope Stability of Clark County (1975)', 'Geologic Map of the Vancouver Quadrangle' map (1987)', 'LiDAR acquisition project (2002)', Clark County Geographic Information Services: <a href="https://gis.clark.wa.gov/gishome/metadata/#/layer/333" target="_blank" rel="noopener">https://gis.clark.wa.gov/gishome/metadata/#/layer/333</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
-            <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Flood' %}</h4>
+      <div class="hazard-sources">
+        <h4 class="hazard-header flood">{% trans 'Flood' %}</h4>
         <p>FEMA, 2012, Final dFIRM Flood Data - Special flood hazard areas , Federal Emergency Management Agency: <a href="https://gis.clark.wa.gov/gishome/metadata/#/layer/1565" target="_blank" rel="noopener">https://gis.clark.wa.gov/gishome/metadata/#/layer/1565</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
       <div class="hazard-sources">
-        <h4 class="hazard-header">{% trans 'Wildfire' %}</h4>
+        <h4 class="hazard-header wildfire">{% trans 'Wildfire' %}</h4>
         <p>Gilbertson-Day, J.W., Scott, J.H., Vogler, K.C., Brough, A., 2018, Pacific Northwest Quantitative Wildfire Risk Assessment, U.S. Forest Service: <a href="https://oregonexplorer.info/content/pacific-northwest-quantitative-wildfire-risk-assessment" target="_blank" rel="noopener">https://oregonexplorer.info/content/pacific-northwest-quantitative-wildfire-risk-assessment</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
       </div>
     </div>

--- a/disasterinfosite/templates/data.html
+++ b/disasterinfosite/templates/data.html
@@ -1,0 +1,86 @@
+{% load js %}
+{% load i18n %}
+
+{% load render_bundle from webpack_loader %}
+{% load webpack_static from webpack_loader %}
+{% get_current_language as SELECTED_LANGUAGE_CODE %}
+
+<!doctype html>
+<html class="no-js" lang="{{ SELECTED_LANGUAGE_CODE }}">
+{% include "head-meta.html" with file="data" %}
+
+<body>
+{% include "about-header.html" %}
+
+  <div class="content-container">
+    <h2>{% trans "Data sources for PDX Ready" %}</h2>
+    <div class="data-source-container">
+      <h3 class="county-header">{% trans 'Clackamas, Columbia, Multnomah, and Washington Counties, Oregon' %}</h3>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Earthquake' %}</h4>
+        <p>Bauer, J.M., Burns, W.J., Madin, I.P., 2018, Open-File Report O-18-02, Earthquake regional impact analysis for Clackamas, Multnomah, and Washington counties, Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-18-02.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-18-02.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019 .</p>
+        <p>Madin, I.P. and Burns, W.J., 2013, Open-File Report O-13-06, Ground motion, ground deformation, tsunami inundation, coseismic subsidence, and damage potential maps for the 2012 Oregon Resilience Plan for Cascadia Subduction Zone Earthquakes, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-13-06.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-13-06.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Volcano' %}</h4>
+        <p>Schilling, S.P., Doelger, S., Scott, W.E., Pierson, T.C., Costa, J.E., Gardner, C.A., Vallance, J.W., Major, J.J., 2008, Digital Data for Volcano Hazards of the Mount Hood Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1222/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1222/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Schilling, S.P., Doelger, S., D.R. Sherrod, L.G. Mastin, and W.E. Scott, 2008, Digital Data for Volcano Hazards at Newberry Volcano, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1225/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1225/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Schilling, S.P., Doelger, S., C.R. Bacon, L.G. Mastin, K.E. Scott, and M. Nathenson, 2008, Digital Data for Volcano Hazards in the Crater Lake Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1223/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1223/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Schilling, S.P., Doelger, S., Walder, J.S., Gardner, C.A., Conrey, R.M., Fisher, B.J. , 2008, Digital Data for Volcano Hazards in the Mount Jefferson Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1224/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1224/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Schilling, S.P., Doelger, S., Scott, W.E., Iverson, R.M., 2008, Hazard Zones -- Digital Data for Volcano Hazards of the Three Sisters Region, Oregon, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/2007/1221/data.html" target="_blank" rel="noopener">https://pubs.usgs.gov/of/2007/1221/data.html</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Landslide' %}</h4>
+        <p>Burns, W.J., Mickelson, K.A., Madin, I.P., 2016, Open-File Report O-16-02, Landslide Susceptibility Overview Map of Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/ofr/p-O-16-02.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/ofr/p-O-16-02.htm</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Flood' %}</h4>
+        <p>DOGAMI, 2015, Oregon Statewide Flood Hazard Database - Other Flood Studies, Oregon Department of Geology and Mining Industries: <a href="https://spatialdata.oregonexplorer.info/geoportal/details;id=584a7d2df65d4751979b23b746d92024" target="_blank" rel="noopener">https://spatialdata.oregonexplorer.info/geoportal/details;id=584a7d2df65d4751979b23b746d92024</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Appleby, C.A. and Bauer, J.M., 2018, Special Paper 50, Flood risk assessment for the Columbia Corridor drainage districts in Multnomah County, Oregon, Oregon Department of Geology and Mining Industries: <a href="https://www.oregongeology.org/pubs/sp/p-SP-50.htm" target="_blank" rel="noopener">https://www.oregongeology.org/pubs/sp/p-SP-50.htm</a>, {% trans 'accessed' %} {% trans 'August' %} 8, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Wildfire' %}</h4>
+        <p>Gilbertson-Day, J.W., Scott, J.H., Vogler, K.C., Brough, A., 2018, Pacific Northwest Quantitative Wildfire Risk Assessment, U.S. Forest Service and Oregon Department of Forestry: <a href="https://tools.oregonexplorer.info/OE_HtmlViewer/index.html?viewer=wildfireplanning" target="_blank" rel="noopener">https://tools.oregonexplorer.info/OE_HtmlViewer/index.html?viewer=wildfireplanning</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+    </div>
+    <div class="data-source-container">
+      <h3 class="county-header">{% trans 'Clark County, Washington' %}</h3>
+            <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Earthquake' %}</h4>
+        <p>USGS, 2017, M 9.3 Scenario Earthquake - Cascadia Megathrust - whole CSZ Characteristic largest M branch (MMI Shakemap Data), U.S. Geological Survey: <a href="https://earthquake.usgs.gov/scenarios/eventpage/bssc2014cascadia_sub0_m9p34_se/shakemap/intensity" target="_blank" rel="noopener">https://earthquake.usgs.gov/scenarios/eventpage/bssc2014cascadia_sub0_m9p34_se/shakemap/intensity</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+        <p>Palmer,S.P., Magsino, S.L., Bilderback, E.L., Poelstra, J.L., Folger, D.S., Niggemann, R.A., 2004, Open File Report 2004-20 Liquefaction Susceptibility and Site Class Maps of Washington State, Clark County, Washington Department of Natural Resources: <a href="ftp://ww4.dnr.wa.gov/geology/pubs/ofr04-20/ofr2004-20_sheet11_clark_liq.pdf" target="_blank" rel="noopener">ftp://ww4.dnr.wa.gov/geology/pubs/ofr04-20/ofr2004- 20_sheet11_clark_liq.pdf</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Volcano' %}</h4>
+        <p>Wolfe, E.W. and Pierson, T.C. , 1995, Open-File Report 95–497: Volcanic-hazard zonation for Mount St. Helens, Washington, U.S. Geological Survey: <a href="https://pubs.usgs.gov/of/1996/0178/" target="_blank" rel="noopener">https://pubs.usgs.gov/of/1996/0178/</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Landslide' %}</h4>
+        <p>Washington DNR and Merrick & Company, 1975, 1987, 2002, Landslide Hazard Areas: combined from 'Slope Stability of Clark County (1975)', 'Geologic Map of the Vancouver Quadrangle' map (1987)', 'LiDAR acquisition project (2002)', Clark County Geographic Information Services: <a href="https://gis.clark.wa.gov/gishome/metadata/#/layer/333" target="_blank" rel="noopener">https://gis.clark.wa.gov/gishome/metadata/#/layer/333</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+            <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Flood' %}</h4>
+        <p>FEMA, 2012, Final dFIRM Flood Data - Special flood hazard areas , Federal Emergency Management Agency: <a href="https://gis.clark.wa.gov/gishome/metadata/#/layer/1565" target="_blank" rel="noopener">https://gis.clark.wa.gov/gishome/metadata/#/layer/1565</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+      <div class="hazard-sources">
+        <h4 class="hazard-header">{% trans 'Wildfire' %}</h4>
+        <p>Gilbertson-Day, J.W., Scott, J.H., Vogler, K.C., Brough, A., 2018, Pacific Northwest Quantitative Wildfire Risk Assessment, U.S. Forest Service: <a href="https://oregonexplorer.info/content/pacific-northwest-quantitative-wildfire-risk-assessment" target="_blank" rel="noopener">https://oregonexplorer.info/content/pacific-northwest-quantitative-wildfire-risk-assessment</a>, {% trans 'accessed' %}: {% trans 'June' %} 17, 2019.</p>
+      </div>
+    </div>
+    <div class="data-source-container">
+      {% trans 'Questions or concerns about the data? Contact:' %}
+      <ul>
+        <li><a href="https://msc.fema.gov/portal/resources/contact" target="_blank" rel="noopener">Federal Emergency Management Agency (FEMA)</a> - <i>{% trans 'flood' %}</i></li>
+        <li><a href="mailto:dogami-info@oregon.gov">Oregon Department of Geology and Mining Industries</a> - <i>{% trans 'earthquake' %}, {% trans 'landslide' %}, {% trans 'flood' %}</i></li>
+        <li><a href="https://answers.usgs.gov/" target="_blank" rel="noopener">United States Geological Survey (USGS)</a> - <i>{% trans 'earthquake' %}, {% trans 'volcano' %}</i></li>
+        <li><a href="http://pyrologix.com/contact/" target="_blank" rel="noopener">United States Forest Service and Pyrologix</a> - <i>{% trans 'wildfire' %}</i></li>
+        <li><a href="mailto:geology@dnr.wa.gov">Washington Department of Natural Resources (DNR)</a> - <i>{% trans 'earthquake' %}, {% trans 'landslide' %}</i></li>
+      </ul>
+    </div>
+  </div>
+
+{% include "geek_box.html" %}
+{% include "page-end-meta.html" with file="data" %}
+
+</body>
+</html>

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -30,8 +30,9 @@
         </div>
         {% block disclaimer %}
         <div class="disclaimer-container">
+          {% webpack_static 'build/data-sources.pdf' as data_source_link %}
            <p>
-              {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original data sources. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
+              {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original <a href="{{ data_source_link }}" target="_blank">data sources</a>. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
           </p>
         </div>
         {% endblock disclaimer %}

--- a/disasterinfosite/templates/index.html
+++ b/disasterinfosite/templates/index.html
@@ -30,7 +30,7 @@
         </div>
         {% block disclaimer %}
         <div class="disclaimer-container">
-          {% webpack_static 'build/data-sources.pdf' as data_source_link %}
+          {% url 'data' as data_source_link %}
            <p>
               {% blocktrans with area_name=settings.area_name %}This site uses the most up-to-date hazard risk data available for {{ area_name }}. The user of this site is responsible for verifying any particular information with the original <a href="{{ data_source_link }}" target="_blank">data sources</a>. Although these data represent the best current assessment of hazards, they are not predictive of future events. The descriptions of risk and how to prepare for those risks are based on best information from the American Red Cross and the Federal Emergency Management Agency.{% endblocktrans %}
           </p>

--- a/disasterinfosite/urls.py
+++ b/disasterinfosite/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
 urlpatterns += i18n_patterns(url(r'^$', views.app_view, name='index'))
 urlpatterns += i18n_patterns(url(r'^about/$', views.about_view, name='about'))
 urlpatterns += i18n_patterns(url(r'^prepare/$', views.prepare_view, name='prepare'))
+urlpatterns += i18n_patterns(url(r'^data/$', views.data_view, name='data'))
 
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/disasterinfosite/views.py
+++ b/disasterinfosite/views.py
@@ -111,6 +111,13 @@ def about_view(request):
     }
     return render(request, "about.html", renderData)
 
+@ensure_csrf_cookie
+def data_view(request):
+    renderData = {
+    'settings': SiteSettings.get_solo()
+    }
+    return render(request, "data.html", renderData)
+
 
 @ensure_csrf_cookie
 def prepare_view(request):

--- a/disasterinfosite/webpack.config.js
+++ b/disasterinfosite/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
     vendor: ["leaflet", "jquery", "slick-carousel"],
     app: "./static/js/app.js",
     prepare: "./static/js/prepare.js",
-    about: "./static/js/about.js"
+    about: "./static/js/about.js",
+    data: "./static/js/data.js"
   },
 
   output: {


### PR DESCRIPTION
From Liz: https://trello.com/c/FVhLKaFo (only scroll in the x-axis for the swipey tabs)

Add a link to the data sources from the disclaimer (https://trello.com/c/UA5kxSFG), and give the data sources their own page. It looks like this:

![image](https://user-images.githubusercontent.com/547883/64213527-27b80900-ce62-11e9-8d2a-69b8e8510a6e.png)

(English version also available)