### PR TITLE
Fix embed snugget to stop getting video errors

### DIFF
--- a/disasterinfosite/templates/snugget_embed.html
+++ b/disasterinfosite/templates/snugget_embed.html
@@ -2,7 +2,7 @@
 
 {% block snugget-content %}
   {{ snugget.text | safe }}
-  {% video snugget.embed as my_video %}
+  {% video snugget.video as my_video %}
     {% video my_video "large" %}
   {% endvideo %}
 {% endblock %}


### PR DESCRIPTION
It turns out that this mystery error was Django trying to tell me that I wasn't handling video embed snuggets correctly: https://trello.com/c/tTJgEBR4

Now our winter weather preparedness video shows up!