### PR TITLE
Make this display a blank string until we get a real translation

### DIFF
--- a/disasterinfosite/locale/es/LC_MESSAGES/django.po
+++ b/disasterinfosite/locale/es/LC_MESSAGES/django.po
@@ -474,6 +474,7 @@ msgid ""
 "You may have already done some of it! You can use the checklist at the "
 "bottom of this page to keep track of how much you've done."
 msgstr ""
+" "
 
 #: templates/prepare.html:84
 msgid "This activity"


### PR DESCRIPTION
This is a stopgap so the English text doesn't show up on the Spanish version of the site.