### PR TITLE
Do not show survey and prepare links

### DIFF
--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -18,11 +18,6 @@
     </a>
   </div>
 </div>
-{% if surveyHeader %}
-  <a class="survey-link" href="http://bit.ly/pdx-t2" target="_blank" rel="noopener">
-    <div class="survey-button">{% trans "Feedback Survey" %}</div>
-  </a>
-{% endif %}
 
 {% endblock info-instructions %}
 
@@ -37,7 +32,6 @@
     {% for group, hazard in data.items %}
       <a class="hazard-link caps" href="#{{group.name}}">{{group.display_name}}</a>
     {% endfor %}
-    <a class="prepare-link caps" href="{% url 'prepare' %}" target="_blank">{% trans "Prepare!" %}</a>
   </div>
 {% endblock hazard-menu %}
 

--- a/disasterinfosite/templates/header.html
+++ b/disasterinfosite/templates/header.html
@@ -16,11 +16,7 @@
       {% include "language_selector.html" %}
     </div>
   </div>
-{% if surveyHeader %}
-  <a class="survey-link hide-for-medium-up" href="{{ surveyUrl }}" target="_blank" rel="noopener">
-    <div class="survey-button {{ surveyClass }}">{% trans "Feedback Survey" %}</div>
-  </a>
-{% endif %}
+
   {% block search %}
   {% trans "Find Me" as find_me %}
     <div class="location-form" role="search" aria-label="location-search">
@@ -46,8 +42,3 @@
     {% include "language_selector.html" %}
   </div>
 </header>
-{% if surveyHeader %}
-  <a class="survey-link hide-for-small" href="{{ surveyUrl }}" target="_blank" rel="noopener">
-    <div class="survey-button {{ surveyClass }}">{% trans "Feedback Survey" %}</div>
-  </a>
-{% endif %}


### PR DESCRIPTION
The PDX folks don't want the prepare links in results pages, and the survey seems to have expired.